### PR TITLE
Remove any existing jobs on subsequent runs

### DIFF
--- a/Enable-DuckDns.ps1
+++ b/Enable-DuckDns.ps1
@@ -121,7 +121,7 @@ If($Break){
 # Clear any existing jobs
 $jobs = @("RunDuckDnsUpdate", "StartDuckDnsJob")
 foreach ($job in $jobs) {
-    If(Get-ScheduledJob $job) {
+    If(Get-ScheduledJob $job -ErrorAction SilentlyContinue) {
         Unregister-ScheduledJob $job
     }
 }

--- a/Enable-DuckDns.ps1
+++ b/Enable-DuckDns.ps1
@@ -118,6 +118,14 @@ If($Break){
     Break
 }
 
+# Clear any existing jobs
+$jobs = @("RunDuckDnsUpdate", "StartDuckDnsJob")
+foreach ($job in $jobs) {
+    If(Get-ScheduledJob $job) {
+        Unregister-ScheduledJob $job
+    }
+}
+
 # Check to see if the "DuckDNS Updater" event log source already exists,
 # and if it doesn't then create it
 if (!([System.Diagnostics.EventLog]::SourceExists("DuckDNS Updater"))){

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ PowerShell Version 4.0
 
 ## Sample Usage
 `.\Enable-DuckDNS.ps1 -MyDomains "wibble,pibble" -Token YourDuckDNSToken -Interval 5`
+
+## Deleting Jobs
+Run the following commands to delete the DuckDNS jobs.
+
+`Unregister-ScheduledJob "RunDuckDnsUpdate"`
+`Unregister-ScheduledJob "StartDuckDnsJob"`

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ PowerShell Version 4.0
 Run the following commands to delete the DuckDNS jobs.
 
 `Unregister-ScheduledJob "RunDuckDnsUpdate"`
+
 `Unregister-ScheduledJob "StartDuckDnsJob"`


### PR DESCRIPTION
- Script would error when rerunning the script to add or change domains. It now removes
any existing jobs.
- Updated the README to include the cmdlets to remove jobs.